### PR TITLE
All application buttons with transition

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,22 +4,23 @@
         <main-component></main-component>
 
         <back-to-top visibleoffset="800">
-            <button class="bg-gray-800 text-white fixed bottom-0 right-0 my-10 mx-10 p-2 rounded-md focus:outline-none" aria-label="Back to top">
+            <app-button class="bg-gray-800 hover:bg-gray-900 text-white fixed bottom-0 right-0 my-10 mx-10 p-2 rounded-md focus:outline-none" aria-label="Back to top">
                 <svg class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
                     <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd"/>
                 </svg>
-            </button>
+            </app-button>
         </back-to-top>
     </div>
 </template>
 
 <script>
+import AppButton from "@/components/utilities/AppButton.vue";
 import HeaderComponent from "./components/Header";
 import MainComponent from "./components/Main";
 import BackToTop from "vue-backtotop";
 
 export default {
-    components: { HeaderComponent, MainComponent, BackToTop },
+    components: { AppButton, HeaderComponent, MainComponent, BackToTop },
 
     data() {
         return {

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -6,7 +6,7 @@
                 <div class="flex items-center justify-center mt-5 ">
                     <div class="mt-2 md:mt-0">
                         <span v-for="category in categories" :key="category.name">
-                            <button @click="searchText = category.name" class="ml-2 mt-2 px-3 py-1 cursor-pointer hover:bg-gray-700 hover:text-gray-200 motion-reduce:transition-none transition-colors duration-150 ease-in-out rounded text-sm focus:outline-none" :class="category.name === searchText? 'bg-gray-700 text-gray-200' : 'bg-gray-200 text-gray-700'">{{ category.name }}</button>
+                            <app-button @click="searchText = category.name" class="ml-2 mt-2 px-3 py-1 cursor-pointer hover:bg-gray-700 hover:text-gray-200 rounded text-sm focus:outline-none" :class="category.name === searchText? 'bg-gray-700 text-gray-200' : 'bg-gray-200 text-gray-700'">{{ category.name }}</app-button>
                         </span> 
                     </div>
                 </div>
@@ -28,6 +28,9 @@
 </template>
 
 <script>
+// Application components
+import AppButton from "@/components/utilities/AppButton.vue";
+
 // Alerts
 import AlertsSuccessPop from "./ui/Alerts/SuccessPop";
 import AlertsInfoPop from "./ui/Alerts/InfoPop";
@@ -87,6 +90,7 @@ import Component from "../models/ComponentsFilter";
 
 export default {
     components: {
+        AppButton,
         AlertsSuccessPop,
         AlertsInfoPop,
         AlertsWarningPop,

--- a/src/components/utilities/AppButton.vue
+++ b/src/components/utilities/AppButton.vue
@@ -1,0 +1,15 @@
+<template>
+  <button
+    v-bind="$attrs"
+    v-on="$listeners"
+    class="motion-reduce:transition-none transition-colors duration-150 ease-in-out"
+  >
+    <slot />
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'AppButton'
+}
+</script>

--- a/src/components/utilities/AppButton.vue
+++ b/src/components/utilities/AppButton.vue
@@ -9,6 +9,9 @@
 </template>
 
 <script>
+/**
+ * Button wrapper component that added some smooth color transition.
+ */
 export default {
   name: 'AppButton'
 }

--- a/src/components/utilities/ViewComponent.vue
+++ b/src/components/utilities/ViewComponent.vue
@@ -7,24 +7,24 @@
                 </div>
 
                 <div class="mt-4 md:mt-0">
-                    <button @click="rtl =! rtl" class="rounded-md p-1 hover:text-gray-700 hover:bg-gray-400 focus:outline-none" :class="rtl? 'bg-gray-400 text-gray-700' : 'bg-gray-200 text-gray-600'" aria-label="Rtl">
+                    <app-button @click="rtl =! rtl" class="rounded-md p-1 hover:text-gray-700 hover:bg-gray-400 focus:outline-none" :class="rtl? 'bg-gray-400 text-gray-700' : 'bg-gray-200 text-gray-600'" aria-label="Rtl">
                         <svg class="h-6 w-6 fill-current" viewBox="0 0 24 24" fill="none">
                             <path d="M16 13V11.5H10V9.5H16V8L19 10.5L16 13Z" fill="currentColor" />
                             <path d="M8 17V15.5H14V13.5H8V12L5 14.5L8 17Z" fill="currentColor" />
                         </svg>
-                    </button>
+                    </app-button>
 
-                    <button @click="viewCode =! viewCode" class="mx-4 rounded-md p-1 hover:text-gray-700 hover:bg-gray-400 focus:outline-none" :class="viewCode? 'bg-gray-400 text-gray-700' : 'bg-gray-200 text-gray-600'" aria-label="View code snippet">
+                    <app-button @click="viewCode =! viewCode" class="mx-4 rounded-md p-1 hover:text-gray-700 hover:bg-gray-400 focus:outline-none" :class="viewCode? 'bg-gray-400 text-gray-700' : 'bg-gray-200 text-gray-600'" aria-label="View code snippet">
                         <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
                         </svg>
-                    </button>
+                    </app-button>
 
-                    <button v-clipboard:success="onCopy" v-clipboard:copy="code" class="bg-gray-200 rounded-md p-1 text-gray-600 hover:text-gray-700 hover:bg-gray-400 focus:outline-none" aria-label="Copy">
+                    <app-button v-clipboard:success="onCopy" v-clipboard:copy="code" class="bg-gray-200 rounded-md p-1 text-gray-600 hover:text-gray-700 hover:bg-gray-400 focus:outline-none" aria-label="Copy">
                         <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                         </svg>
-                    </button>
+                    </app-button>
                 </div>
             </div>
         </div>
@@ -52,12 +52,14 @@
 </template>
 
 <script>
+import AppButton from "@/components/utilities/AppButton.vue";
 import CodeSnippet from "./CodeSnippet";
 
 export default {
     props: ['name' , 'code'],
 
     components: {
+        AppButton,
         CodeSnippet
     },
 


### PR DESCRIPTION
Following up https://github.com/merakiui/merakiui/pull/21

---

I've added the same transition to all application buttons (not the ui components). In order to do so I abstracted everything into an `AppButton` component instead of adding the same classes everywhere. I can also setup a utility class for that if you think it is better.

By the end I added some hover effect into the scroll-top button and used `AppButton`. I can also remove it if that is too much.